### PR TITLE
fixed link to examples MNE website

### DIFF
--- a/MNEPython/Introduction.ipynb
+++ b/MNEPython/Introduction.ipynb
@@ -26,7 +26,7 @@
     "## Using the pipeline in self-studies and education\n",
     "\n",
     "The MNE Python toolbox has an excellent selection of [Tutorials](https://mne.tools/stable/auto_tutorials/index.html)\n",
-    " and [Examples](https://mne.tools/dev/auto_examples/index.html). Nevertheless, the options are so many that the learning curve for new users is very steep. The FLUX pipeline provides a set of procedures for what we consider best practice at this moment in time. Consistent with an Open Science approach, the FLUX pipeline provides a validated and documented approach for MEG data analysis. Each analysis step comes with explanations and illustrations. Furthermore, questions are embedded in the tutorials which will be useful for self-study or they can be used in educational settings.\n",
+    " and [Examples](https://mne.tools/stable/auto_examples/index.html). Nevertheless, the options are so many that the learning curve for new users is very steep. The FLUX pipeline provides a set of procedures for what we consider best practice at this moment in time. Consistent with an Open Science approach, the FLUX pipeline provides a validated and documented approach for MEG data analysis. Each analysis step comes with explanations and illustrations. Furthermore, questions are embedded in the tutorials which will be useful for self-study or they can be used in educational settings.\n",
     "\n",
     "We will not link back to sections on the MNE Python webpage as they will change over time; nevertheless, users are are strongly encouraged to consult the website as they develop their skills and insight. \n",
     "\n",


### PR DESCRIPTION
The current introduction contains a link (Examples page) to the dev version of the MNE website. I modified it to link to the stable version